### PR TITLE
Fix byte indexes, negative values and unhandled bytes

### DIFF
--- a/laird.js
+++ b/laird.js
@@ -1,24 +1,58 @@
-/* 
- * Decoder function for The Things Network to unpack the basic temperature/humidity payload of the Laird RS1xx Sensors
- *
- * This function was created by Cameron Sharp at Sensational Systems - cameron@sensational.systems
+/**
+ * Basic decoder for Laird RS1xx Sensors, only supporting uplink message
+ * type 0x01 as defined in RS1xx LoRa Protocol v2.7.
  */
-
 function Decoder(bytes, f_port) {
-  if (bytes[0] == 0x01){
-    humidity_dec = bytes[4];
-    humidity_int = bytes[5];
-    temp_dec = bytes[7];
-    temp_int = bytes[8];
-    
-    humidity = humidity_int + (humidity_dec / 100);
-    temp = temp_int + (temp_dec / 100);
-    
-  }
-  return {
+  var messageType = bytes[0];
+
+  // All Sensor-to-Server messages have the same options byte format.
+  // The options byte is always at byte index 1.
+  var options = bytes[1];
+
+  var decoded = {
     raw: bytes,
     f_port: f_port,
-    temp: temp,
-    humidity: humidity
+    messageType: messageType,
+    options: options,
+    // Just for debugging: show all 8 bits, ensuring leading zeroes
+    optionFlags: '0b' + ('00000000' + options.toString(2)).slice(-8),
+    sensorRequestForServerTime: (options & 1<<0) > 0,
+    sensorConfigurationError: (options & 1<<1) > 0,
+    sensorAlarmFlag: (options & 1<<2) > 0,
+    sensorResetFlag: (options & 1<<3) > 0,
+    sensorFaultFlag: (options & 1<<4) > 0
   };
+
+  switch (messageType) {
+    // 0x01 = Send Temp RH Data Notification
+    case 0x01:
+      decoded.humidity = bytes[3] + bytes[2]/100;
+  
+      // For temperature, both the integer and fractional parts are signed:
+      // a positive value of 27.43 has a fractional portion of 43 and an
+      // integer portion 27, and a negative value -15.87 uses -87 and -15.
+      // Sign-extend a single byte to 32 bits to make JavaScript understand
+      // negative values, by shifting 24 bits to the left, followed by a
+      // sign-propagating right shift of the same number of bits:
+      decoded.temperature = (bytes[5]<<24>>24) + (bytes[4]<<24>>24)/100;
+  
+      decoded.batteryIndex = bytes[6];
+      decoded.batteryCapacity = {
+        0: '0-5%',
+        1: '5-20%',
+        2: '20-40%',
+        3: '40-60%',
+        4: '60-80%',
+        5: '80-100%'
+      }[decoded.batteryIndex] || 'Unsupported value';
+  
+      decoded.alarmMsgCount = bytes[7]<<8 | bytes[8];
+      decoded.backlogMsgCount = bytes[9]<<8 | bytes[10];
+      break;
+      
+    default:
+      decoded.error = 'Unsupported message type';
+  }
+  
+  return decoded;
 }


### PR DESCRIPTION
This PR fixes some bugs, and decodes a few more details, still only supporting message type 0x01.

Page 13 in the [RS1xx LoRaWAN Protocol 2.6 on your website](https://connectedthings.store/gb/index.php?controller=attachment&id_attachment=86) shows a different byte order for the message type 0x01 that is handled in this decoder. Also, temperature is signed, for which page 1 explains:

> Temperature and humidity values are represented as two-byte values. The first byte is the fractional portion of the value and the second byte is the integer portion of the value. For example, a temperature of 27.43 degrees C has a fractional portion of 43 and an integer portion of 27. A temperature of -15.87 C would have a fractional portion of -87 and an integer portion of -15.
>
> The following are the equations for temperature and humidity:
>
> - Temp = IntegerPortion + (FractionalPortion/100)
> - Humidity = Integer Portion + (Fractional Portion/100)
>
> Note: Temperature uses signed eight-bit values, while humidity uses unsigned eight-bit values. However, because humidity cannot be negative, the sign bit is never set and there is no practical difference between using signed or unsigned values for humidity.

Page 13 in that document also shows *signed* integers `int8_t` for both the fractional and integer parts.

:warning: **I do not own this device.** 

According to [a TTN Forum post](https://www.thethingsnetwork.org/forum/t/laird-rs1xx-payload-format/19313/12), an example payload for a negative temperature may be `01010000DBF20500000000`. The Laird documentation shows `01001E0141190200000000` as an example, but does not document the expected values.

Aside: Laird also provides an updated [RS1xx LoRa Protocol v2.7](https://connectivity-staging.s3.us-east-2.amazonaws.com/2020-04/CS-AN-RS1xx-LoRa-Protocol%20v2_7.pdf).
